### PR TITLE
Update simple-get 2.4.0 to 4.0.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "fast-url-parser": "^1.1.3",
     "is-absolute-url": "^2.1.0",
-    "simple-get": "^2.4.0"
+    "simple-get": "^4.0.1"
   },
   "devDependencies": {
     "chai": "^4.3.4",


### PR DESCRIPTION
This potentially fixes a security vulnerability in the dependency.
The breaking changes from 2.4.0 to 4.0.1 involved adoption of ES6
and dropping support for EOL Node.js versions. Neither should be a
problem here, I would expect.

Reference: https://github.com/advisories/GHSA-wpg7-2c88-r8xv