### PR TITLE
Handing empty robots.txt string

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -20,7 +20,11 @@ const cleanSpaces = (rawString) => rawString.replace(whitespace, '').trim();
 const splitOnLines = (string) => string.split(lineEndings);
 
 const robustSplit = (string) => {
-  return !string.includes('<html>') ? [...string.match(recordSlices)].map(cleanSpaces) : [];
+  const matches = (null === string || undefined === string) ? null : string.match(recordSlices);
+  if (!matches) {
+    return [];
+  }
+  return !string.includes('<html>') ? [...matches].map(cleanSpaces) : [];
 };
 
 const parseRecord = (line) => {

--- a/test/parser/can-parse-test-files.js
+++ b/test/parser/can-parse-test-files.js
@@ -4,6 +4,7 @@ const exampleRobotsBcc = require('../test-data/example-robots-txt-bcc.js');
 const exampleRobotsKarwei = require('../test-data/example-robots-txt-karwei.js');
 const exampleRobotsShort = require('../test-data/example-robots-txt-short.js');
 const exampleRobotsZalando = require('../test-data/example-robots-txt-zalando.js');
+const exampleRobotsEmpty = require('../test-data/example-robots-txt-empty.js');
 const parse = require('../../src/parser.js');
 
 const { expect } = chai;
@@ -64,6 +65,14 @@ describe('can-parse-test-files', () => {
     expect(parseResult['*'].disallow).to.have.lengthOf(16);
     expect(parseResult['screaming frog seo spider'].allow).to.have.lengthOf(0);
     expect(parseResult['screaming frog seo spider'].disallow).to.have.lengthOf(1);
+    expect(parseResult.sitemaps).to.have.lengthOf(0);
+  });
+
+  it('Should completely parse robots-txt-empty', () => {
+    const parseResult = parse(exampleRobotsEmpty);
+    const userAgents = Object.keys(parseResult).filter((val) => val !== 'sitemaps' && val !== 'host');
+    expect(userAgents).to.have.lengthOf(0);
+    expect(parseResult).to.have.keys(['sitemaps']);
     expect(parseResult.sitemaps).to.have.lengthOf(0);
   });
 });

--- a/test/test-data/example-robots-txt-empty.js
+++ b/test/test-data/example-robots-txt-empty.js
@@ -1,0 +1,1 @@
+module.exports = "";


### PR DESCRIPTION
I got bugs when the robots.txt was empty on the server, possibly due to it missing altogether.

    TypeError: string.match is not a function or its return value is not iterable
      at robustSplit (src/parser.js:23:50)
      at parser (src/parser.js:62:13)
      at Context.<anonymous> (test/parser/can-parse-test-files.js:72:25)
      at process.processImmediate (node:internal/timers:478:21)
